### PR TITLE
feat: Add support for CFF files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,14 @@ The Svelte application depends on the WASM module built from the Rust code.
 
 From the root of this repository, run the following command to build the WASM module:
 
+You need to have [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/) installed.
+
+```bash
+cargo install wasm-pack
+```
+
+Then run the following command to build the WASM module:
+
 ```bash
 cd comtrade_rust
 wasm-pack build --target web

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # comtrade inspector
 
+You need to have [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/) installed.
+
+```bash
+cargo install wasm-pack
+```
 
 Build the WASM module
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -3475,6 +3475,19 @@
 				"node": ">=8.6"
 			}
 		},
+		"node_modules/micromatch/node_modules/picomatch": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/mini-svg-data-uri": {
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
@@ -3698,13 +3711,13 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=8.6"
+				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
@@ -4490,19 +4503,6 @@
 				"url": "https://github.com/sponsors/SuperchupuDev"
 			}
 		},
-		"node_modules/tinyglobby/node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/tinypool": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
@@ -4750,19 +4750,6 @@
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
-		"node_modules/vite/node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/vitefu": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.1.tgz",
@@ -4874,19 +4861,6 @@
 				"vitest": "^2.1.0 || ^3.0.0-0"
 			}
 		},
-		"node_modules/vitest/node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4960,21 +4934,6 @@
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/yaml": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-			"integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
 			}
 		},
 		"node_modules/yocto-queue": {

--- a/app/src/app.html
+++ b/app/src/app.html
@@ -3,11 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<link
-			crossorigin=""
-			href="https://fonts.gstatic.com/"
-			rel="preconnect"
-		/>
+		<link crossorigin="" href="https://fonts.gstatic.com/" rel="preconnect" />
 		<link
 			as="style"
 			href="https://fonts.googleapis.com/css2?display=swap&amp;family=Inter%3Awght%40400%3B500%3B700%3B900&amp;family=Noto+Sans%3Awght%40400%3B500%3B700%3B900"
@@ -20,7 +16,11 @@
 		/>
 		%sveltekit.head%
 	</head>
-	<body data-sveltekit-preload-data="hover" class="bg-[#111418] text-white print:bg-white print:text-black" style="font-family: Inter, &quot;Noto Sans&quot;, sans-serif">
+	<body
+		data-sveltekit-preload-data="hover"
+		class="bg-[#111418] text-white print:bg-white print:text-black"
+		style="font-family: Inter, 'Noto Sans', sans-serif"
+	>
 		<div style="display: contents">%sveltekit.body%</div>
 	</body>
 </html>

--- a/app/src/lib/components/Sidebar.svelte
+++ b/app/src/lib/components/Sidebar.svelte
@@ -1,58 +1,39 @@
-<aside class="w-64 bg-[#181C21] p-6 flex flex-col justify-between print:hidden">
-    <div>
-        <div class="flex items-center gap-2 mb-8">
-            <span
-                class="material-symbols-outlined text-3xl text-[var(--primary-color)]"
-            >
-                insights
-            </span>
-            <h1 class="text-xl font-bold">File Analyzer</h1>
-        </div>
-        <nav class="flex flex-col gap-2">
-            <a
-                class="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-[#283039]"
-                href="/"
-            >
-                <span class="material-symbols-outlined">dashboard</span>
-                <span>Dashboard</span>
-            </a>
-            <a
-                class="flex items-center gap-3 px-3 py-2 rounded-md bg-[var(--primary-color)] text-white"
-                href="/info"
-            >
-                <span class="material-symbols-outlined">description</span>
-                <span>Files</span>
-            </a>
-            <a
-                class="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-[#283039]"
-                href="#"
-            >
-                <span class="material-symbols-outlined">settings</span>
-                <span>Settings</span>
-            </a>
-            <a
-                class="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-[#283039]"
-                href="#"
-            >
-                <span class="material-symbols-outlined">help</span>
-                <span>Help</span>
-            </a>
-            <a
-                class="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-[#283039]"
-                href="#"
-            >
-                <span class="material-symbols-outlined">feedback</span>
-                <span>Feedback</span>
-            </a>
-        </nav>
-    </div>
-    <div>
-        <a
-            class="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-[#283039]"
-            href="#"
-        >
-            <span class="material-symbols-outlined">logout</span>
-            <span>Logout</span>
-        </a>
-    </div>
+<aside class="flex w-64 flex-col justify-between bg-[#181C21] p-6 print:hidden">
+	<div>
+		<div class="mb-8 flex items-center gap-2">
+			<span class="material-symbols-outlined text-3xl text-[var(--primary-color)]"> insights </span>
+			<h1 class="text-xl font-bold">File Analyzer</h1>
+		</div>
+		<nav class="flex flex-col gap-2">
+			<a class="flex items-center gap-3 rounded-md px-3 py-2 hover:bg-[#283039]" href="/">
+				<span class="material-symbols-outlined">dashboard</span>
+				<span>Dashboard</span>
+			</a>
+			<a
+				class="flex items-center gap-3 rounded-md bg-[var(--primary-color)] px-3 py-2 text-white"
+				href="/info"
+			>
+				<span class="material-symbols-outlined">description</span>
+				<span>Files</span>
+			</a>
+			<a class="flex items-center gap-3 rounded-md px-3 py-2 hover:bg-[#283039]" href="#">
+				<span class="material-symbols-outlined">settings</span>
+				<span>Settings</span>
+			</a>
+			<a class="flex items-center gap-3 rounded-md px-3 py-2 hover:bg-[#283039]" href="#">
+				<span class="material-symbols-outlined">help</span>
+				<span>Help</span>
+			</a>
+			<a class="flex items-center gap-3 rounded-md px-3 py-2 hover:bg-[#283039]" href="#">
+				<span class="material-symbols-outlined">feedback</span>
+				<span>Feedback</span>
+			</a>
+		</nav>
+	</div>
+	<div>
+		<a class="flex items-center gap-3 rounded-md px-3 py-2 hover:bg-[#283039]" href="#">
+			<span class="material-symbols-outlined">logout</span>
+			<span>Logout</span>
+		</a>
+	</div>
 </aside>

--- a/app/src/lib/components/Upload.svelte
+++ b/app/src/lib/components/Upload.svelte
@@ -5,166 +5,196 @@
 // RELEVANT FILES: app/src/routes/+page.svelte, comtrade_rust/src/lib.rs
 -->
 <script lang="ts">
-    import { createEventDispatcher } from 'svelte';
+	import { createEventDispatcher } from 'svelte';
 
-    let { parse_comtrade } = $props();
+	let { parse_comtrade } = $props();
 
-    let cfgFile = $state<File | null>(null);
-    let datFile = $state<File | null>(null);
-    let cffFile = $state<File | null>(null);
-    let isDragging = $state(false);
-    let error = $state<string | null>(null);
+	let cfgFile = $state<File | null>(null);
+	let datFile = $state<File | null>(null);
+	let cffFile = $state<File | null>(null);
+	let isDragging = $state(false);
+	let error = $state<string | null>(null);
+	let selectedEncoding = $state('utf-8');
 
-    const dispatch = createEventDispatcher<{
-        analyse: { data: unknown };
-    }>();
+	const dispatch = createEventDispatcher<{
+		analyse: {
+			data: unknown;
+			cfgFileName?: string;
+			datFileName?: string;
+			cffFileName?: string;
+		};
+	}>();
 
-    function handleFiles(files: FileList) {
-        for (const file of files) {
-            const lowerCaseName = file.name.toLowerCase();
-            if (lowerCaseName.endsWith('.cfg')) {
-                cfgFile = file;
-                cffFile = null;
-            } else if (lowerCaseName.endsWith('.dat')) {
-                datFile = file;
-                cffFile = null;
-            } else if (lowerCaseName.endsWith('.cff')) {
-                cffFile = file;
-                cfgFile = null;
-                datFile = null;
-            }
-        }
-    }
+	function handleFiles(files: FileList) {
+		for (const file of files) {
+			const lowerCaseName = file.name.toLowerCase();
+			if (lowerCaseName.endsWith('.cfg')) {
+				cfgFile = file;
+				cffFile = null;
+			} else if (lowerCaseName.endsWith('.dat')) {
+				datFile = file;
+				cffFile = null;
+			} else if (lowerCaseName.endsWith('.cff')) {
+				cffFile = file;
+				cfgFile = null;
+				datFile = null;
+			}
+		}
+	}
 
-    function onDrop(event: DragEvent) {
-        event.preventDefault();
-        isDragging = false;
-        if (event.dataTransfer?.files) {
-            handleFiles(event.dataTransfer.files);
-        }
-    }
+	function onDrop(event: DragEvent) {
+		event.preventDefault();
+		isDragging = false;
+		if (event.dataTransfer?.files) {
+			handleFiles(event.dataTransfer.files);
+		}
+	}
 
-    function onDragOver(event: DragEvent) {
-        event.preventDefault();
-        isDragging = true;
-    }
+	function onDragOver(event: DragEvent) {
+		event.preventDefault();
+		isDragging = true;
+	}
 
-    function onDragLeave() {
-        isDragging = false;
-    }
+	function onDragLeave() {
+		isDragging = false;
+	}
 
-    function onFileSelected(event: Event) {
-        const input = event.target as HTMLInputElement;
-        if (input.files) {
-            handleFiles(input.files);
-        }
-    }
+	function onFileSelected(event: Event) {
+		const input = event.target as HTMLInputElement;
+		if (input.files) {
+			handleFiles(input.files);
+		}
+	}
 
-    async function analyseFiles() {
-        error = null;
-        try {
-            let result;
-            let fileInfo;
+	async function analyseFiles() {
+		error = null;
+		try {
+			let result;
+			let fileInfo;
 
-            if (cffFile) {
-                const cffData = new Uint8Array(await cffFile.arrayBuffer());
-                result = parse_comtrade(null, null, cffData);
-                fileInfo = { cffFileName: cffFile.name };
-            } else if (cfgFile && datFile) {
-                const cfgData = new Uint8Array(await cfgFile.arrayBuffer());
-                const datData = new Uint8Array(await datFile.arrayBuffer());
-                result = parse_comtrade(cfgData, datData, null);
-                fileInfo = { cfgFileName: cfgFile.name, datFileName: datFile.name };
-            } else {
-                return;
-            }
+			if (cffFile) {
+				const cffData = new Uint8Array(await cffFile.arrayBuffer());
+				result = parse_comtrade(null, null, cffData, null);
+				fileInfo = { cffFileName: cffFile.name };
+			} else if (cfgFile && datFile) {
+				const cfgData = new Uint8Array(await cfgFile.arrayBuffer());
+				const datData = new Uint8Array(await datFile.arrayBuffer());
+				result = parse_comtrade(cfgData, datData, null, selectedEncoding);
+				fileInfo = { cfgFileName: cfgFile.name, datFileName: datFile.name };
+			} else {
+				return;
+			}
 
-            dispatch('analyse', {
-                data: result,
-                ...fileInfo
-            });
-        } catch (e) {
-            error = e instanceof Error ? e.message : String(e);
-        }
-    }
+			dispatch('analyse', {
+				data: result,
+				...fileInfo
+			});
+		} catch (e) {
+			error = e instanceof Error ? e.message : String(e);
+		}
+	}
 </script>
 
 <div class="mx-auto flex max-w-4xl flex-col items-center">
-    <div class="mb-12 text-center">
-        <h1 class="text-white text-4xl font-bold leading-tight tracking-tighter">
-            Upload COMTRADE Files
-        </h1>
-        <p class="mt-4 max-w-2xl text-gray-400 text-lg font-normal leading-relaxed">
-            Drag and drop your .CFG and .DAT files as a pair, or a single .CFF file. You can also click the button to browse your computer.
-        </p>
-    </div>
-    <div class="w-full max-w-2xl">
-        <div
-            class="flex flex-col items-center justify-center w-full h-80 rounded-lg border-2 border-dashed p-8 transition-colors {isDragging
-                ? 'border-blue-500 bg-gray-800/80'
-                : 'border-gray-700 bg-gray-800/50'}"
-            on:dragover={onDragOver}
-            on:dragleave={onDragLeave}
-            on:drop={onDrop}
-        >
-            <input type="file" id="file-input" class="hidden" multiple on:change={onFileSelected} accept=".cfg,.dat,.cff" />
-            <label for="file-input" class="flex flex-col items-center gap-4 cursor-pointer">
-                <div class="text-blue-500">
-                    <span class="material-symbols-outlined text-6xl">
-                        upload_file
-                    </span>
-                </div>
-                <p class="text-white text-xl font-bold leading-tight">
-                    Drag &amp; drop files here
-                </p>
-                <p class="text-gray-400 text-base font-normal">
-                    Supported file types: .CFG, .DAT, .CFF
-                </p>
-                <p class="text-gray-500 text-sm">or</p>
-                <span class="flex items-center justify-center gap-2 rounded-md h-12 px-6 bg-blue-500 text-white text-base font-bold leading-normal tracking-wide shadow-lg hover:bg-opacity-90 transition-all">
-                    <span class="material-symbols-outlined">
-                        folder_open
-                    </span>
-                    <span class="truncate">Browse Files</span>
-                </span>
-            </label>
-        </div>
-        <div class="mt-4 space-y-2">
-            {#if cffFile}
-                <div class="flex justify-between items-center bg-gray-800 p-2 rounded">
-                    <span class="text-white">{cffFile.name}</span>
-                    <button on:click={() => cffFile = null} class="text-red-500 hover:text-red-400">Remove</button>
-                </div>
-            {/if}
-            {#if cfgFile}
-                <div class="flex justify-between items-center bg-gray-800 p-2 rounded">
-                    <span class="text-white">{cfgFile.name}</span>
-                    <button on:click={() => cfgFile = null} class="text-red-500 hover:text-red-400">Remove</button>
-                </div>
-            {/if}
-            {#if datFile}
-                <div class="flex justify-between items-center bg-gray-800 p-2 rounded">
-                    <span class="text-white">{datFile.name}</span>
-                    <button on:click={() => datFile = null} class="text-red-500 hover:text-red-400">Remove</button>
-                </div>
-            {/if}
-        </div>
+	<div class="mb-12 text-center">
+		<h1 class="text-4xl leading-tight font-bold tracking-tighter text-white">
+			Upload COMTRADE Files
+		</h1>
+		<p class="mt-4 max-w-2xl text-lg leading-relaxed font-normal text-gray-400">
+			Drag and drop your .CFG and .DAT files as a pair, or a single .CFF file. You can also click
+			the button to browse your computer.
+		</p>
+	</div>
+	<div class="w-full max-w-2xl">
+		<div
+			class="flex h-80 w-full flex-col items-center justify-center rounded-lg border-2 border-dashed p-8 transition-colors {isDragging
+				? 'border-blue-500 bg-gray-800/80'
+				: 'border-gray-700 bg-gray-800/50'}"
+			ondragover={onDragOver}
+			ondragleave={onDragLeave}
+			ondrop={onDrop}
+		>
+			<input
+				type="file"
+				id="file-input"
+				class="hidden"
+				multiple
+				onchange={onFileSelected}
+				accept=".cfg,.dat,.cff"
+			/>
+			<label for="file-input" class="flex cursor-pointer flex-col items-center gap-4">
+				<div class="text-blue-500">
+					<span class="material-symbols-outlined text-6xl"> upload_file </span>
+				</div>
+				<p class="text-xl leading-tight font-bold text-white">Drag &amp; drop files here</p>
+				<p class="text-base font-normal text-gray-400">Supported file types: .CFG, .DAT, .CFF</p>
+				<p class="text-sm text-gray-500">or</p>
+				<span
+					class="hover:bg-opacity-90 flex h-12 items-center justify-center gap-2 rounded-md bg-blue-500 px-6 text-base leading-normal font-bold tracking-wide text-white shadow-lg transition-all"
+				>
+					<span class="material-symbols-outlined"> folder_open </span>
+					<span class="truncate">Browse Files</span>
+				</span>
+			</label>
+		</div>
+		<div class="mt-4 space-y-2">
+			{#if cffFile}
+				<div class="flex items-center justify-between rounded bg-gray-800 p-2">
+					<span class="text-white">{cffFile.name}</span>
+					<button onclick={() => (cffFile = null)} class="text-red-500 hover:text-red-400"
+						>Remove</button
+					>
+				</div>
+			{/if}
+			{#if cfgFile}
+				<div class="flex items-center justify-between rounded bg-gray-800 p-2">
+					<span class="text-white">{cfgFile.name}</span>
+					<button onclick={() => (cfgFile = null)} class="text-red-500 hover:text-red-400"
+						>Remove</button
+					>
+				</div>
+			{/if}
+			{#if datFile}
+				<div class="flex items-center justify-between rounded bg-gray-800 p-2">
+					<span class="text-white">{datFile.name}</span>
+					<button onclick={() => (datFile = null)} class="text-red-500 hover:text-red-400"
+						>Remove</button
+					>
+				</div>
+			{/if}
+		</div>
 
-        {#if (cfgFile && datFile) || cffFile}
-            <div class="mt-6 text-center">
-                <button
-                    on:click={analyseFiles}
-                    class="rounded-md bg-green-600 px-8 py-3 text-lg font-semibold text-white shadow-lg hover:bg-green-500 transition-colors disabled:bg-gray-600 disabled:cursor-not-allowed"
-                >
-                    Analyse
-                </button>
-            </div>
-        {/if}
+		{#if cfgFile && datFile}
+			<div class="mt-4">
+				<label for="encoding-select" class="block text-sm font-medium text-gray-300"
+					>CFG File Encoding:</label
+				>
+				<select
+					id="encoding-select"
+					bind:value={selectedEncoding}
+					class="mt-1 block w-full rounded-md border-gray-600 bg-gray-700 text-white shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+				>
+					<option value="utf-8">UTF-8</option>
+					<option value="latin1">ISO-8859-1 (Latin-1)</option>
+				</select>
+			</div>
+		{/if}
 
-        {#if error}
-            <div class="mt-4 text-center text-red-400">
-                <p>Error: {error}</p>
-            </div>
-        {/if}
-    </div>
+		{#if (cfgFile && datFile) || cffFile}
+			<div class="mt-6 text-center">
+				<button
+					onclick={analyseFiles}
+					class="rounded-md bg-green-600 px-8 py-3 text-lg font-semibold text-white shadow-lg transition-colors hover:bg-green-500 disabled:cursor-not-allowed disabled:bg-gray-600"
+				>
+					Analyse
+				</button>
+			</div>
+		{/if}
+
+		{#if error}
+			<div class="mt-4 text-center text-red-400">
+				<p>Error: {error}</p>
+			</div>
+		{/if}
+	</div>
 </div>

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -6,10 +6,10 @@
 -->
 <script lang="ts">
 	import { onMount } from 'svelte';
-    import { goto } from '$app/navigation';
+	import { goto } from '$app/navigation';
 	import init, { parse_comtrade, init_panic_hook } from 'comtrade_rust';
-    import Upload from '$lib/components/Upload.svelte';
-    import { analysisResult } from '$lib/store';
+	import Upload from '$lib/components/Upload.svelte';
+	import { analysisResult } from '$lib/store';
 
 	let initialized = $state(false);
 	let error = $state<string | null>(null);
@@ -20,33 +20,39 @@
 			init_panic_hook();
 			initialized = true;
 		} catch (err) {
-			console.error("Failed to initialize WASM:", err);
+			console.error('Failed to initialize WASM:', err);
 			error = err instanceof Error ? err.message : String(err);
 		}
 	});
 
-    function handleAnalyse(
-        event: CustomEvent<{ data: unknown; cfgFileName: string; datFileName: string }>
-    ) {
-        const result = {
-            ...(event.detail.data as object),
-            cfgFileName: event.detail.cfgFileName,
-            datFileName: event.detail.datFileName
-        };
-        analysisResult.set(result);
-        goto('/info');
-    }
+	function handleAnalyse(
+		event: CustomEvent<{
+			data: unknown;
+			cfgFileName?: string;
+			datFileName?: string;
+			cffFileName?: string;
+		}>
+	) {
+		const result = {
+			...(event.detail.data as object),
+			cfgFileName: event.detail.cfgFileName,
+			datFileName: event.detail.datFileName,
+			cffFileName: event.detail.cffFileName
+		};
+		analysisResult.set(result);
+		goto('/info');
+	}
 </script>
 
 <div class="container mx-auto p-8">
-    {#if error}
-        <div class="bg-red-500/20 border border-red-500/50 text-red-400 p-4 rounded-lg">
-            <h2 class="font-bold">Error loading WASM module</h2>
-            <p>{error}</p>
-        </div>
-    {:else if initialized}
-        <Upload parse_comtrade={parse_comtrade} on:analyse={handleAnalyse} />
-    {:else}
-        <p>Loading WASM module...</p>
-    {/if}
+	{#if error}
+		<div class="rounded-lg border border-red-500/50 bg-red-500/20 p-4 text-red-400">
+			<h2 class="font-bold">Error loading WASM module</h2>
+			<p>{error}</p>
+		</div>
+	{:else if initialized}
+		<Upload {parse_comtrade} on:analyse={handleAnalyse} />
+	{:else}
+		<p>Loading WASM module...</p>
+	{/if}
 </div>

--- a/app/src/routes/info/+page.svelte
+++ b/app/src/routes/info/+page.svelte
@@ -21,8 +21,9 @@
 	}
 
 	interface FileInfo {
-		cfgFileName: string;
-		datFileName: string;
+		cfgFileName?: string;
+		datFileName?: string;
+		cffFileName?: string;
 	}
 
 	interface ComtradeInfo extends FileInfo {
@@ -74,8 +75,12 @@
 		<h3 class="mb-4 text-xl font-semibold">File Information</h3>
 		{#if result}
 			<div class="mb-4 text-sm text-gray-400">
-				<p><span class="font-semibold text-gray-200">CFG File:</span> {result.cfgFileName}</p>
-				<p><span class="font-semibold text-gray-200">DAT File:</span> {result.datFileName}</p>
+				{#if result.cffFileName}
+					<p><span class="font-semibold text-gray-200">CFF File:</span> {result.cffFileName}</p>
+				{:else}
+					<p><span class="font-semibold text-gray-200">CFG File:</span> {result.cfgFileName}</p>
+					<p><span class="font-semibold text-gray-200">DAT File:</span> {result.datFileName}</p>
+				{/if}
 			</div>
 			<div class="grid grid-cols-1 gap-x-8 gap-y-4 md:grid-cols-[2fr_1fr]">
 				<div class="flex justify-between border-b border-[#3b4754] pb-2">

--- a/app/svelte.config.js
+++ b/app/svelte.config.js
@@ -18,7 +18,7 @@ const config = {
 			precompress: false
 		}),
 		paths: {
-			base: process.env.NODE_ENV === 'production' ? '/comtrade-inspector' : '',
+			base: process.env.NODE_ENV === 'production' ? '/comtrade-inspector' : ''
 		}
 	}
 };

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -1,12 +1,12 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-  content: ['./src/**/*.{html,js,svelte,ts}'],
-  theme: {
-    extend: {
-      colors: {
-        'primary-color': 'var(--primary-color)'
-      }
-    },
-  },
-  plugins: [],
-}
+	content: ['./src/**/*.{html,js,svelte,ts}'],
+	theme: {
+		extend: {
+			colors: {
+				'primary-color': 'var(--primary-color)'
+			}
+		}
+	},
+	plugins: []
+};

--- a/comtrade_rust/Cargo.lock
+++ b/comtrade_rust/Cargo.lock
@@ -85,6 +85,7 @@ version = "0.1.0"
 dependencies = [
  "comtrade",
  "console_error_panic_hook",
+ "encoding_rs",
  "serde",
  "serde-wasm-bindgen",
  "wasm-bindgen",
@@ -170,6 +171,15 @@ checksum = "58a94ace95092c5acb1e97a7e846b310cfbd499652f72297da7493f618a98d73"
 dependencies = [
  "derive_builder_core",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]

--- a/comtrade_rust/Cargo.toml
+++ b/comtrade_rust/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 wasm-bindgen = "0.2"
@@ -12,3 +12,4 @@ comtrade = { git = "https://github.com/drewsilcock/comtrade.git", rev = "ad281b6
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.4"
 console_error_panic_hook = "0.1.7"
+encoding_rs = "0.8.33"

--- a/comtrade_rust/Cargo.toml
+++ b/comtrade_rust/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 
 [dependencies]
 wasm-bindgen = "0.2"


### PR DESCRIPTION
This commit introduces support for parsing COMTRADE data from CFF files, in addition to the existing CFG/DAT pair functionality.

Changes include:
- Updated the `parse_comtrade` Rust function to handle either a CFF file or a CFG/DAT pair.
- Modified the Svelte `Upload` component to accept `.cff` files and call the updated Rust function.
- Updated the info page to correctly display the name of the parsed file(s), whether it's a single CFF file or a CFG/DAT pair.