### PR TITLE
feat: Add analog waveform plot view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ From the root of this repository, run the following command to build the Svelte 
 
 ```bash
 cd app
-npm run dev -- --open
+npm run build
 ```
 
 

--- a/app/npm_output.log
+++ b/app/npm_output.log
@@ -1,0 +1,11 @@
+
+> comtrade-inspector@0.0.1 predev
+> npm run copy-wasm
+
+
+> comtrade-inspector@0.0.1 copy-wasm
+> cp ../comtrade_rust/pkg/comtrade_rust_bg.wasm static/
+
+
+> comtrade-inspector@0.0.1 dev
+> vite dev

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -8,7 +8,8 @@
 			"name": "comtrade-inspector",
 			"version": "0.0.1",
 			"dependencies": {
-				"comtrade_rust": "file:../comtrade_rust/pkg"
+				"comtrade_rust": "file:../comtrade_rust/pkg",
+				"uplot": "^1.6.32"
 			},
 			"devDependencies": {
 				"@eslint/compat": "^1.2.5",
@@ -40,7 +41,8 @@
 		},
 		"../comtrade_rust/pkg": {
 			"name": "comtrade_rust",
-			"version": "0.1.0"
+			"version": "0.1.0",
+			"license": "MIT"
 		},
 		"node_modules/@babel/code-frame": {
 			"version": "7.27.1",
@@ -4619,6 +4621,12 @@
 				"eslint": "^8.57.0 || ^9.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
 			}
+		},
+		"node_modules/uplot": {
+			"version": "1.6.32",
+			"resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.32.tgz",
+			"integrity": "sha512-KIMVnG68zvu5XXUbC4LQEPnhwOxBuLyW1AHtpm6IKTXImkbLgkMy+jabjLgSLMasNuGGzQm/ep3tOkyTxpiQIw==",
+			"license": "MIT"
 		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -31,7 +31,7 @@
 				"prettier-plugin-tailwindcss": "^0.6.11",
 				"svelte": "^5.0.0",
 				"svelte-check": "^4.0.0",
-				"tailwindcss": "^4.0.0",
+				"tailwindcss": "^4.1.13",
 				"typescript": "^5.0.0",
 				"typescript-eslint": "^8.20.0",
 				"vite": "^7.0.4",

--- a/app/package.json
+++ b/app/package.json
@@ -46,6 +46,7 @@
 		"vitest-browser-svelte": "^0.1.0"
 	},
 	"dependencies": {
-		"comtrade_rust": "file:../comtrade_rust/pkg"
+		"comtrade_rust": "file:../comtrade_rust/pkg",
+		"uplot": "^1.6.32"
 	}
 }

--- a/app/package.json
+++ b/app/package.json
@@ -38,7 +38,7 @@
 		"prettier-plugin-tailwindcss": "^0.6.11",
 		"svelte": "^5.0.0",
 		"svelte-check": "^4.0.0",
-		"tailwindcss": "^4.0.0",
+		"tailwindcss": "^4.1.13",
 		"typescript": "^5.0.0",
 		"typescript-eslint": "^8.20.0",
 		"vite": "^7.0.4",

--- a/app/src/lib/components/AnalogWaveform.svelte
+++ b/app/src/lib/components/AnalogWaveform.svelte
@@ -9,43 +9,44 @@
 	import uPlot from 'uplot';
 	import 'uplot/dist/uPlot.min.css';
 
-	export let timestamps: number[];
-	export let series: { name: string; values: number[]; color: string }[];
-	export let title: string;
+	let { timestamps, series, title } = $props<{
+		timestamps: number[];
+		series: { name: string; values: number[]; color: string }[];
+		title: string;
+	}>();
 
 	let chartContainer: HTMLDivElement;
-	let plot: uPlot;
+	let plot: uPlot | null = null;
+
+	$effect(() => {
+		if (plot) {
+			plot.destroy();
+		}
+		if (chartContainer) {
+			const data = [timestamps, ...series.map((s) => s.values)];
+			const uPlotSeries: uPlot.Series[] = [
+				{},
+				...series.map((s) => ({
+					label: s.name,
+					stroke: s.color,
+					width: 2
+				}))
+			];
+			const opts: uPlot.Options = {
+				title: title,
+				width: chartContainer.clientWidth,
+				height: 400,
+				series: uPlotSeries,
+				axes: [
+					{ label: 'Time (s)' },
+					{ label: 'Value' }
+				]
+			};
+			plot = new uPlot(opts, data, chartContainer);
+		}
+	});
 
 	onMount(() => {
-		const data = [timestamps, ...series.map((s) => s.values)];
-
-		const uPlotSeries: uPlot.Series[] = [
-			{},
-			...series.map((s) => ({
-				label: s.name,
-				stroke: s.color,
-				width: 2
-			}))
-		];
-
-		const opts: uPlot.Options = {
-			title: title,
-			width: 800,
-			height: 400,
-			series: uPlotSeries,
-			axes: [
-				{
-					label: 'Time (s)'
-				},
-				{
-					label: 'Value'
-				}
-			]
-		};
-
-		plot = new uPlot(opts, data, chartContainer);
-
-		// Resize the chart when the window is resized
 		const resizeObserver = new ResizeObserver(() => {
 			if (plot) {
 				plot.setSize({

--- a/app/src/lib/components/AnalogWaveform.svelte
+++ b/app/src/lib/components/AnalogWaveform.svelte
@@ -1,0 +1,70 @@
+<!--
+// app/src/lib/components/AnalogWaveform.svelte
+// This file contains the AnalogWaveform component.
+// This file exists to display a single analog waveform plot using uPlot.
+// RELEVANT FILES: app/src/routes/waveform/+page.svelte
+-->
+<script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+	import uPlot from 'uplot';
+	import 'uplot/dist/uPlot.min.css';
+
+	export let timestamps: number[];
+	export let values: number[];
+	export let channelName: string;
+	export let strokeColor: string = 'rgb(75, 192, 192)';
+
+	let chartContainer: HTMLDivElement;
+	let plot: uPlot;
+
+	onMount(() => {
+		const data = [timestamps, values];
+
+		const opts: uPlot.Options = {
+			title: channelName,
+			width: 800,
+			height: 400,
+			series: [
+				{},
+				{
+					label: channelName,
+					stroke: strokeColor,
+					width: 2
+				}
+			],
+			axes: [
+				{
+					label: 'Time (s)'
+				},
+				{
+					label: 'Value'
+				}
+			]
+		};
+
+		plot = new uPlot(opts, data, chartContainer);
+
+		// Resize the chart when the window is resized
+		const resizeObserver = new ResizeObserver(() => {
+			if (plot) {
+				plot.setSize({
+					width: chartContainer.clientWidth,
+					height: 400
+				});
+			}
+		});
+		resizeObserver.observe(chartContainer);
+
+		return () => {
+			resizeObserver.disconnect();
+		};
+	});
+
+	onDestroy(() => {
+		if (plot) {
+			plot.destroy();
+		}
+	});
+</script>
+
+<div bind:this={chartContainer}></div>

--- a/app/src/lib/components/AnalogWaveform.svelte
+++ b/app/src/lib/components/AnalogWaveform.svelte
@@ -10,28 +10,29 @@
 	import 'uplot/dist/uPlot.min.css';
 
 	export let timestamps: number[];
-	export let values: number[];
-	export let channelName: string;
-	export let strokeColor: string = 'rgb(75, 192, 192)';
+	export let series: { name: string; values: number[]; color: string }[];
+	export let title: string;
 
 	let chartContainer: HTMLDivElement;
 	let plot: uPlot;
 
 	onMount(() => {
-		const data = [timestamps, values];
+		const data = [timestamps, ...series.map((s) => s.values)];
+
+		const uPlotSeries: uPlot.Series[] = [
+			{},
+			...series.map((s) => ({
+				label: s.name,
+				stroke: s.color,
+				width: 2
+			}))
+		];
 
 		const opts: uPlot.Options = {
-			title: channelName,
+			title: title,
 			width: 800,
 			height: 400,
-			series: [
-				{},
-				{
-					label: channelName,
-					stroke: strokeColor,
-					width: 2
-				}
-			],
+			series: uPlotSeries,
 			axes: [
 				{
 					label: 'Time (s)'

--- a/app/src/lib/components/Sidebar.svelte
+++ b/app/src/lib/components/Sidebar.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import { base } from '$app/paths';
+	import { analysisResult } from '$lib/store';
+	import { page } from '$app/stores';
 </script>
 
 <aside class="flex w-64 flex-col justify-between bg-[#181C21] p-6 print:hidden">
@@ -9,29 +11,35 @@
 			<h1 class="text-xl font-bold">File Analyzer</h1>
 		</div>
 		<nav class="flex flex-col gap-2">
-			<a class="flex items-center gap-3 rounded-md px-3 py-2 hover:bg-[#283039]" href={base || '/'}>
-				<span class="material-symbols-outlined">dashboard</span>
-				<span>Dashboard</span>
-			</a>
 			<a
-				class="flex items-center gap-3 rounded-md bg-[var(--primary-color)] px-3 py-2 text-white"
-				href={`${base}/info`}
+				class="flex items-center gap-3 rounded-md px-3 py-2 hover:bg-[#283039]"
+				href={base || '/'}
+				class:bg-[var(--primary-color)]={$page.url.pathname === `${base}/`}
+				class:text-white={$page.url.pathname === `${base}/`}
 			>
-				<span class="material-symbols-outlined">description</span>
-				<span>Files</span>
+				<span class="material-symbols-outlined">upload_file</span>
+				<span>Upload</span>
 			</a>
-			<a class="flex items-center gap-3 rounded-md px-3 py-2 hover:bg-[#283039]" href="#">
-				<span class="material-symbols-outlined">settings</span>
-				<span>Settings</span>
-			</a>
-			<a class="flex items-center gap-3 rounded-md px-3 py-2 hover:bg-[#283039]" href="#">
-				<span class="material-symbols-outlined">help</span>
-				<span>Help</span>
-			</a>
-			<a class="flex items-center gap-3 rounded-md px-3 py-2 hover:bg-[#283039]" href="#">
-				<span class="material-symbols-outlined">feedback</span>
-				<span>Feedback</span>
-			</a>
+			{#if $analysisResult}
+				<a
+					class="flex items-center gap-3 rounded-md px-3 py-2 hover:bg-[#283039]"
+					href={`${base}/info`}
+					class:bg-[var(--primary-color)]={$page.url.pathname === `${base}/info`}
+					class:text-white={$page.url.pathname === `${base}/info`}
+				>
+					<span class="material-symbols-outlined">description</span>
+					<span>File Info</span>
+				</a>
+				<a
+					class="flex items-center gap-3 rounded-md px-3 py-2 hover:bg-[#283039]"
+					href={`${base}/waveform`}
+					class:bg-[var(--primary-color)]={$page.url.pathname === `${base}/waveform`}
+					class:text-white={$page.url.pathname === `${base}/waveform`}
+				>
+					<span class="material-symbols-outlined">show_chart</span>
+					<span>Waveform</span>
+				</a>
+			{/if}
 		</nav>
 	</div>
 	<div>

--- a/app/src/lib/components/Switch.svelte
+++ b/app/src/lib/components/Switch.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+	let {
+		label,
+		fontSize = 16,
+		checked = $bindable(false)
+	} = $props<{
+		label: string;
+		fontSize?: number;
+		checked?: boolean;
+	}>();
+
+	const uniqueID = `switch-${Math.floor(Math.random() * 1000)}`;
+</script>
+
+<div class="s s--slider" style="font-size:{fontSize}px">
+	<span id={uniqueID}>{label}</span>
+	<button
+		role="switch"
+		aria-checked={checked}
+		aria-labelledby={uniqueID}
+		on:click={() => (checked = !checked)}
+	>
+	</button>
+</div>
+
+<style>
+	:root {
+		--accent-color: CornflowerBlue;
+		--gray: #ccc;
+	}
+
+	/* Slider Design Option */
+	.s--slider {
+		display: flex;
+		align-items: center;
+	}
+
+	.s--slider button {
+		width: 3em;
+		height: 1.6em;
+		position: relative;
+		margin: 0 0 0 0.5em;
+		background: var(--gray);
+		border: none;
+		border-radius: 1.5em;
+	}
+
+	.s--slider button::before {
+		content: '';
+		position: absolute;
+		width: 1.3em;
+		height: 1.3em;
+		background: #fff;
+		top: 0.13em;
+		left: 0.15em;
+		transition: transform 0.3s;
+		border-radius: 100%;
+	}
+
+	.s--slider button[aria-checked='true'] {
+		background-color: var(--accent-color);
+	}
+
+	.s--slider button[aria-checked='true']::before {
+		transform: translateX(1.4em);
+	}
+
+	.s--slider button:focus {
+		box-shadow: 0 0px 8px var(--accent-color);
+	}
+</style>

--- a/app/src/routes/info/+page.svelte
+++ b/app/src/routes/info/+page.svelte
@@ -26,6 +26,12 @@
 		cffFileName?: string;
 	}
 
+	interface DigitalChannel {
+		index: number;
+		name: string;
+		initial_value: number;
+	}
+
 	interface ComtradeInfo extends FileInfo {
 		station: string;
 		recording_device_id: string;
@@ -34,6 +40,7 @@
 		data_format: string;
 		frequency: number;
 		analog_channels: AnalogChannel[];
+		digital_channels: DigitalChannel[];
 	}
 
 	let result: ComtradeInfo | null = null;
@@ -159,16 +166,15 @@
 					</tr>
 				</thead>
 				<tbody>
-					<tr class="border-b border-[#3b4754]">
-						<td class="p-3 font-medium">1</td>
-						<td class="p-3 text-[#9dabb9]"> Breaker Status </td>
-						<td class="p-3 text-[#9dabb9]">0</td>
-					</tr>
-					<tr>
-						<td class="p-3 font-medium">2</td>
-						<td class="p-3 text-[#9dabb9]"> Trip Signal </td>
-						<td class="p-3 text-[#9dabb9]">0</td>
-					</tr>
+					{#if result}
+						{#each result.digital_channels as channel (channel.index)}
+							<tr class="border-b border-[#3b4754]">
+								<td class="p-3 font-medium">{channel.index}</td>
+								<td class="p-3 text-[#9dabb9]">{channel.name}</td>
+								<td class="p-3 text-[#9dabb9]">{channel.initial_value}</td>
+							</tr>
+						{/each}
+					{/if}
 				</tbody>
 			</table>
 		</div>

--- a/app/src/routes/waveform/+page.svelte
+++ b/app/src/routes/waveform/+page.svelte
@@ -109,7 +109,7 @@
 					/>
 				</div>
 			{:else}
-				{#each selectedChannels as channelIndex}
+				{#each selectedChannels as channelIndex (channelIndex)}
 					{@const channel = result.analog_channels.find((c) => c.index === channelIndex)}
 					{#if channel}
 						<div>

--- a/app/src/routes/waveform/+page.svelte
+++ b/app/src/routes/waveform/+page.svelte
@@ -1,0 +1,107 @@
+<!--
+// app/src/routes/waveform/+page.svelte
+// This file contains the waveform page of the application.
+// This file exists to display the waveform plots of the analog channels.
+// RELEVANT FILES: app/src/lib/components/AnalogWaveform.svelte, app/src/lib/store.ts
+-->
+<script lang="ts">
+	import { analysisResult } from '$lib/store';
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { base } from '$app/paths';
+	import AnalogWaveform from '$lib/components/AnalogWaveform.svelte';
+
+	let result = $state<any>(null);
+	let selectedChannels = $state<number[]>([]);
+
+	const colors = [
+		'#e6194b',
+		'#3cb44b',
+		'#ffe119',
+		'#4363d8',
+		'#f58231',
+		'#911eb4',
+		'#46f0f0',
+		'#f032e6',
+		'#bcf60c',
+		'#fabebe',
+		'#008080',
+		'#e6beff',
+		'#9a6324',
+		'#fffac8',
+		'#800000',
+		'#aaffc3',
+		'#808000',
+		'#ffd8b1',
+		'#000075',
+		'#808080'
+	];
+
+	onMount(() => {
+		const unsubscribe = analysisResult.subscribe((value) => {
+			if (value) {
+				result = value;
+			} else {
+				goto(`${base}/`);
+			}
+		});
+
+		return () => unsubscribe();
+	});
+
+	function toggleChannel(channelIndex: number) {
+		if (selectedChannels.includes(channelIndex)) {
+			selectedChannels = selectedChannels.filter((i) => i !== channelIndex);
+		} else {
+			selectedChannels = [...selectedChannels, channelIndex];
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>Analog Waveforms</title>
+</svelte:head>
+
+<div class="p-8">
+	<h2 class="text-4xl font-bold tracking-tight">Analog Waveforms</h2>
+
+	{#if result}
+		<div class="my-8">
+			<h3 class="text-xl font-semibold">Select Channels</h3>
+			<div class="mt-4 grid grid-cols-2 gap-4 md:grid-cols-4 lg:grid-cols-6">
+				{#each result.analog_channels as channel (channel.index)}
+					<label class="flex items-center space-x-2">
+						<input
+							type="checkbox"
+							checked={selectedChannels.includes(channel.index)}
+							on:change={() => toggleChannel(channel.index)}
+						/>
+						<span>{channel.name}</span>
+					</label>
+				{/each}
+			</div>
+		</div>
+
+		<div class="space-y-8">
+			{#each selectedChannels as channelIndex}
+				{@const channel = result.analog_channels.find((c) => c.index === channelIndex)}
+				{#if channel}
+					<div>
+						<h3 class="text-lg font-semibold">{channel.name}</h3>
+						<p class="text-sm text-gray-400">{channel.circuit_component_being_monitored} - {channel.units}</p>
+						<div class="mt-4 rounded-lg bg-gray-800 p-4">
+							<AnalogWaveform
+								timestamps={result.timestamps}
+								values={channel.values}
+								channelName={channel.name}
+								strokeColor={colors[channelIndex % colors.length]}
+							/>
+						</div>
+					</div>
+				{/if}
+			{/each}
+		</div>
+	{:else}
+		<p>Loading analysis results...</p>
+	{/if}
+</div>

--- a/comtrade_rust/src/lib.rs
+++ b/comtrade_rust/src/lib.rs
@@ -39,6 +39,8 @@ pub struct SerializableAnalogChannel {
     pub phase: String,
     /// The component of the power system circuit being monitored.
     pub circuit_component_being_monitored: String,
+    /// The waveform data for this channel.
+    pub values: Vec<f64>,
 }
 
 impl From<&AnalogChannel> for SerializableAnalogChannel {
@@ -53,6 +55,7 @@ impl From<&AnalogChannel> for SerializableAnalogChannel {
             offset_adder: channel.offset_adder,
             phase: channel.phase.clone(),
             circuit_component_being_monitored: channel.circuit_component_being_monitored.clone(),
+            values: channel.data.clone(),
         }
     }
 }
@@ -74,6 +77,8 @@ pub struct ComtradeInfo {
     pub frequency: f64,
     /// A list of the analog channels present in the file.
     pub analog_channels: Vec<SerializableAnalogChannel>,
+    /// The timestamps for each data point.
+    pub timestamps: Vec<f64>,
 }
 
 /// Parses a COMTRADE file from its constituent parts.
@@ -141,6 +146,7 @@ pub fn parse_comtrade(
                 data_format: data_format_to_str(&comtrade.data_format).to_string(),
                 frequency: comtrade.line_frequency,
                 analog_channels,
+                timestamps: comtrade.timestamps.clone(),
             };
             serde_wasm_bindgen::to_value(&info).map_err(|e| JsValue::from_str(&e.to_string()))
         }

--- a/design/analog_waveform.html
+++ b/design/analog_waveform.html
@@ -1,0 +1,281 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <link
+            crossorigin=""
+            href="https://fonts.gstatic.com/"
+            rel="preconnect"
+        />
+        <link
+            as="style"
+            href="https://fonts.googleapis.com/css2?display=swap&amp;family=Inter%3Awght%40400%3B500%3B700%3B900&amp;family=Noto+Sans%3Awght%40400%3B500%3B700%3B900"
+            onload="this.rel='stylesheet'"
+            rel="stylesheet"
+        />
+        <title>Stitch Design</title>
+        <link href="data:image/x-icon;base64," rel="icon" type="image/x-icon" />
+        <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+        <link
+            href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined"
+            rel="stylesheet"
+        />
+        <style type="text/tailwindcss">
+            :root {
+                --checkbox-tick-svg: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='rgb(255,255,255)' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");
+            }
+        </style>
+    </head>
+    <body class="bg-[#111418]">
+        <div
+            class="relative flex h-auto min-h-screen w-full flex-row bg-[#18181B] dark group/design-root overflow-x-hidden"
+            style="font-family: Inter, &quot;Noto Sans&quot;, sans-serif"
+        >
+            <aside
+                class="flex flex-col gap-y-6 w-64 bg-[#111418] p-4 text-white"
+            >
+                <div class="flex items-center gap-2 px-2">
+                    <svg
+                        class="h-8 w-8 text-[#1173d4]"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="1.5"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                    >
+                        <path
+                            d="M7.5 14.25v2.25m3-4.5v4.5m3-6.75v6.75m3-9v9M6 20.25h12A2.25 2.25 0 0 0 20.25 18V5.75A2.25 2.25 0 0 0 18 3.5H6A2.25 2.25 0 0 0 3.75 5.75v12.25A2.25 2.25 0 0 0 6 20.25Z"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                        ></path>
+                    </svg>
+                    <h1 class="text-white text-lg font-semibold">
+                        File Analyzer
+                    </h1>
+                </div>
+                <nav class="flex flex-col gap-2 flex-grow">
+                    <a
+                        class="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-[#283039]"
+                        href="#"
+                    >
+                        <span class="material-symbols-outlined text-zinc-400">
+                            description
+                        </span>
+                        <span class="text-sm font-medium">File Info</span>
+                    </a>
+                    <a
+                        class="flex items-center gap-3 px-3 py-2 rounded-md bg-[#283039]"
+                        href="#"
+                    >
+                        <span class="material-symbols-outlined">
+                            show_chart
+                        </span>
+                        <span class="text-sm font-medium">Analog Channels</span>
+                    </a>
+                    <a
+                        class="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-[#283039]"
+                        href="#"
+                    >
+                        <span class="material-symbols-outlined text-zinc-400">
+                            bar_chart
+                        </span>
+                        <span class="text-sm font-medium"
+                            >Digital Channels</span
+                        >
+                    </a>
+                    <a
+                        class="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-[#283039]"
+                        href="#"
+                    >
+                        <span class="material-symbols-outlined text-zinc-400">
+                            settings
+                        </span>
+                        <span class="text-sm font-medium">Settings</span>
+                    </a>
+                    <a
+                        class="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-[#283039]"
+                        href="#"
+                    >
+                        <span class="material-symbols-outlined text-zinc-400">
+                            help
+                        </span>
+                        <span class="text-sm font-medium">Help</span>
+                    </a>
+                </nav>
+                <div class="flex flex-col">
+                    <a
+                        class="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-[#283039]"
+                        href="#"
+                    >
+                        <span class="material-symbols-outlined text-zinc-400">
+                            logout
+                        </span>
+                        <span class="text-sm font-medium">Logout</span>
+                    </a>
+                </div>
+            </aside>
+            <main class="flex-1 bg-[#212121] rounded-l-2xl">
+                <div class="p-8">
+                    <h2 class="text-white text-4xl font-bold mb-8">
+                        Analog Channels
+                    </h2>
+                    <div class="bg-[#111418] rounded-xl p-6">
+                        <h3 class="text-white text-xl font-semibold mb-4">
+                            Select Channels
+                        </h3>
+                        <div
+                            class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4 mb-8"
+                        >
+                            <label
+                                class="flex items-center gap-3 p-3 rounded-lg hover:bg-[#283039] cursor-pointer"
+                            >
+                                <input
+                                    class="h-5 w-5 rounded-md border-[#3b4754] border-2 bg-transparent text-[#1172d4] checked:bg-[#1172d4] checked:border-[#1172d4] checked:bg-[image:var(--checkbox-tick-svg)] focus:ring-2 focus:ring-offset-0 focus:ring-offset-[#111418] focus:ring-[#1172d4] focus:outline-none"
+                                    type="checkbox"
+                                />
+                                <span class="text-white text-base"
+                                    >Channel 1</span
+                                >
+                            </label>
+                            <label
+                                class="flex items-center gap-3 p-3 rounded-lg hover:bg-[#283039] cursor-pointer"
+                            >
+                                <input
+                                    class="h-5 w-5 rounded-md border-[#3b4754] border-2 bg-transparent text-[#1172d4] checked:bg-[#1172d4] checked:border-[#1172d4] checked:bg-[image:var(--checkbox-tick-svg)] focus:ring-2 focus:ring-offset-0 focus:ring-offset-[#111418] focus:ring-[#1172d4] focus:outline-none"
+                                    type="checkbox"
+                                />
+                                <span class="text-white text-base"
+                                    >Channel 2</span
+                                >
+                            </label>
+                            <label
+                                class="flex items-center gap-3 p-3 rounded-lg hover:bg-[#283039] cursor-pointer"
+                            >
+                                <input
+                                    class="h-5 w-5 rounded-md border-[#3b4754] border-2 bg-transparent text-[#1172d4] checked:bg-[#1172d4] checked:border-[#1172d4] checked:bg-[image:var(--checkbox-tick-svg)] focus:ring-2 focus:ring-offset-0 focus:ring-offset-[#111418] focus:ring-[#1172d4] focus:outline-none"
+                                    type="checkbox"
+                                />
+                                <span class="text-white text-base"
+                                    >Channel 3</span
+                                >
+                            </label>
+                            <label
+                                class="flex items-center gap-3 p-3 rounded-lg hover:bg-[#283039] cursor-pointer"
+                            >
+                                <input
+                                    class="h-5 w-5 rounded-md border-[#3b4754] border-2 bg-transparent text-[#1172d4] checked:bg-[#1172d4] checked:border-[#1172d4] checked:bg-[image:var(--checkbox-tick-svg)] focus:ring-2 focus:ring-offset-0 focus:ring-offset-[#111418] focus:ring-[#1172d4] focus:outline-none"
+                                    type="checkbox"
+                                />
+                                <span class="text-white text-base"
+                                    >Channel 4</span
+                                >
+                            </label>
+                            <label
+                                class="flex items-center gap-3 p-3 rounded-lg hover:bg-[#283039] cursor-pointer"
+                            >
+                                <input
+                                    class="h-5 w-5 rounded-md border-[#3b4754] border-2 bg-transparent text-[#1172d4] checked:bg-[#1172d4] checked:border-[#1172d4] checked:bg-[image:var(--checkbox-tick-svg)] focus:ring-2 focus:ring-offset-0 focus:ring-offset-[#111418] focus:ring-[#1172d4] focus:outline-none"
+                                    type="checkbox"
+                                />
+                                <span class="text-white text-base"
+                                    >Channel 5</span
+                                >
+                            </label>
+                        </div>
+                        <h3 class="text-white text-xl font-semibold mb-4">
+                            Waveform Plot
+                        </h3>
+                        <div
+                            class="rounded-xl border border-[#3b4754] p-6 bg-[#18181B]"
+                        >
+                            <div class="flex flex-col gap-4">
+                                <p class="text-white text-lg font-medium">
+                                    Selected Channels
+                                </p>
+                                <div class="min-h-[250px]">
+                                    <svg
+                                        fill="none"
+                                        height="100%"
+                                        preserveAspectRatio="none"
+                                        viewBox="-3 0 478 150"
+                                        width="100%"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                        <path
+                                            d="M0 149V109C18.1538 109 18.1538 21 36.3077 21C54.4615 21 54.4615 41 72.6154 41C90.7692 41 90.7692 93 108.923 93C127.077 93 127.077 33 145.231 33C163.385 33 163.385 101 181.538 101C199.692 101 199.692 61 217.846 61C236 61 236 45 254.154 45C272.308 45 272.308 121 290.462 121C308.615 121 308.615 149 326.769 149C344.923 149 344.923 1 363.077 1C381.231 1 381.231 81 399.385 81C417.538 81 417.538 129 435.692 129C453.846 129 453.846 25 472 25V149H0Z"
+                                            fill="url(#paint0_linear_1131_5935)"
+                                        ></path>
+                                        <path
+                                            d="M0 109C18.1538 109 18.1538 21 36.3077 21C54.4615 21 54.4615 41 72.6154 41C90.7692 41 90.7692 93 108.923 93C127.077 93 127.077 33 145.231 33C163.385 33 163.385 101 181.538 101C199.692 101 199.692 61 217.846 61C236 61 236 45 254.154 45C272.308 45 272.308 121 290.462 121C308.615 121 308.615 149 326.769 149C344.923 149 344.923 1 363.077 1C381.231 1 381.231 81 399.385 81C417.538 81 417.538 129 435.692 129C453.846 129 453.846 25 472 25"
+                                            stroke="#1172d4"
+                                            stroke-linecap="round"
+                                            stroke-width="3"
+                                        ></path>
+                                        <defs>
+                                            <linearGradient
+                                                gradientUnits="userSpaceOnUse"
+                                                id="paint0_linear_1131_5935"
+                                                x1="236"
+                                                x2="236"
+                                                y1="1"
+                                                y2="149"
+                                            >
+                                                <stop
+                                                    stop-color="#1172d4"
+                                                    stop-opacity="0.5"
+                                                ></stop>
+                                                <stop
+                                                    offset="1"
+                                                    stop-color="#111418"
+                                                    stop-opacity="0"
+                                                ></stop>
+                                            </linearGradient>
+                                        </defs>
+                                    </svg>
+                                </div>
+                                <div
+                                    class="flex justify-between border-t border-dashed border-zinc-600 pt-2"
+                                >
+                                    <span
+                                        class="text-[#9dabb9] text-xs font-medium"
+                                        >0s</span
+                                    >
+                                    <span
+                                        class="text-[#9dabb9] text-xs font-medium"
+                                        >1s</span
+                                    >
+                                    <span
+                                        class="text-[#9dabb9] text-xs font-medium"
+                                        >2s</span
+                                    >
+                                    <span
+                                        class="text-[#9dabb9] text-xs font-medium"
+                                        >3s</span
+                                    >
+                                    <span
+                                        class="text-[#9dabb9] text-xs font-medium"
+                                        >4s</span
+                                    >
+                                    <span
+                                        class="text-[#9dabb9] text-xs font-medium"
+                                        >5s</span
+                                    >
+                                </div>
+                            </div>
+                        </div>
+                        <div class="flex justify-end mt-8">
+                            <button
+                                class="flex items-center justify-center gap-2 min-w-[120px] rounded-lg h-12 px-6 bg-[#1172d4] text-white text-base font-semibold hover:bg-blue-600 transition-colors"
+                            >
+                                <span class="material-symbols-outlined">
+                                    update
+                                </span>
+                                <span>Update Plot</span>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </main>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
This commit introduces a new view for plotting analog waveforms from a
COMTRADE file.

The new view is located at the `/waveform` route and allows the user to
select one or more analog channels to be plotted as small multiples.
Each waveform is plotted with a different color using the uPlot library.

The following changes were made:
- Modified the Rust backend to include waveform data (timestamps and
  values) in the analysis result.
- Created a new Svelte component `AnalogWaveform.svelte` to wrap the
  uPlot library.
- Created a new route `/waveform` to display the waveform plots.
- Updated the sidebar to include a link to the new waveform view,
  which is only visible after a file has been analyzed.