### PR TITLE
Fix timestamp scaling in Rust COMTRADE parser

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -9018,22 +9018,6 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/yaml": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-			"extraneous": true,
-			"license": "ISC",
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/eemeli"
-			}
-		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",

--- a/comtrade_rust/Cargo.lock
+++ b/comtrade_rust/Cargo.lock
@@ -56,9 +56,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -84,6 +84,7 @@ dependencies = [
 name = "comtrade_rust"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "comtrade",
  "console_error_panic_hook",
  "encoding_rs",

--- a/comtrade_rust/Cargo.toml
+++ b/comtrade_rust/Cargo.toml
@@ -21,3 +21,4 @@ thiserror = "1"
 js-sys = "0.3.91"
 web-sys = { version = "0.3.91", features = ["console"] }
 regex = "1.11"
+chrono = "0.4.45"

--- a/comtrade_rust/src/lib.rs
+++ b/comtrade_rust/src/lib.rs
@@ -273,7 +273,7 @@ pub fn parse_comtrade(
 
     match result {
         Ok(Ok(comtrade)) => {
-            let trigger_time_seconds = comtrade.trigger_time.and_utc().timestamp();
+            let trigger_offset_seconds = (comtrade.trigger_time - comtrade.start_time).num_microseconds().unwrap_or(0) as f64 / 1_000_000.0;
 
             let mut timestamps_us = Vec::new();
             let mut current_time_us = 0.0;
@@ -290,9 +290,9 @@ pub fn parse_comtrade(
                 last_end_sample = rate_info.end_sample_number;
             }
 
-            let absolute_timestamps: Vec<f64> = timestamps_us
+            let timestamps: Vec<f64> = timestamps_us
                 .iter()
-                .map(|&t_us| trigger_time_seconds as f64 + (t_us / 1_000_000.0))
+                .map(|&t_us| t_us / 1_000_000.0)
                 .collect();
 
             let analog_channels: Vec<SerializableAnalogChannel> = comtrade
@@ -311,8 +311,8 @@ pub fn parse_comtrade(
                     };
                     let skew_timestamps: Vec<f64> = (0..ch.data.len())
                         .map(|i| {
-                            ch.timestamp_at(i, &absolute_timestamps)
-                                .unwrap_or(absolute_timestamps[i])
+                            ch.timestamp_at(i, &timestamps)
+                                .unwrap_or(timestamps[i])
                         })
                         .collect();
 
@@ -398,7 +398,7 @@ pub fn parse_comtrade(
                         let mut rms = (sum_sq / window_size as f64).sqrt();
                         if rms < sag_threshold {
                             sag_detected = true;
-                            sag_start_time = absolute_timestamps[window_size - 1];
+                            sag_start_time = timestamps[window_size - 1];
                             analysis_notes.push(format!(
                                 "Possible voltage sag detected on channel '{}' at {:.4} seconds.",
                                 channel.name, sag_start_time
@@ -416,7 +416,7 @@ pub fn parse_comtrade(
                             rms = (sum_sq / window_size as f64).sqrt();
                             if rms < sag_threshold {
                                 sag_detected = true;
-                                sag_start_time = absolute_timestamps[i];
+                                sag_start_time = timestamps[i];
                                 analysis_notes.push(format!("Possible voltage sag detected on channel '{}' at {:.4} seconds.", channel.name, sag_start_time));
                                 break;
                             }
@@ -439,7 +439,7 @@ pub fn parse_comtrade(
 
                         for (j, &val) in states.iter().enumerate() {
                             if val == 1 {
-                                let trip_time = absolute_timestamps[j];
+                                let trip_time = timestamps[j];
                                 if trip_time > sag_start_time {
                                     trip_found = true;
                                     let trip_delay = trip_time - sag_start_time;
@@ -472,11 +472,11 @@ pub fn parse_comtrade(
                 frequency: comtrade.line_frequency,
                 analog_channels,
                 digital_channels,
-                timestamps: absolute_timestamps,
+                timestamps,
                 warnings,
                 errors,
                 analysis_notes,
-                trigger_timestamp: trigger_time_seconds as f64,
+                trigger_timestamp: trigger_offset_seconds,
             };
             serde_wasm_bindgen::to_value(&info)
                 .map_err(|e| WasmComtradeError::SerializationError(e.to_string()))


### PR DESCRIPTION
Fixes a timestamp scaling issue where absolute Unix epochs were being used instead of seconds relative to the recording's start.

---
*PR created automatically by Jules for task [10921094643170603260](https://jules.google.com/task/10921094643170603260) started by @marcusholmgren*